### PR TITLE
fix(cli): 跳过 OpenCode 异常负 token 记录，避免同步 400

### DIFF
--- a/cli/src/domain/aggregator.test.ts
+++ b/cli/src/domain/aggregator.test.ts
@@ -21,4 +21,35 @@ describe("aggregateToBuckets", () => {
     expect(bucket.reasoningTokens).toBe(10);
     expect(bucket.totalTokens).toBe(195);
   });
+
+  it("skips malformed entries with negative token counts", () => {
+    const [bucket] = aggregateToBuckets([
+      {
+        source: "codex",
+        model: "gpt-5.4",
+        project: "tokenarena",
+        timestamp: new Date("2026-03-26T10:00:00.000Z"),
+        inputTokens: 100,
+        outputTokens: 60,
+        cachedTokens: 25,
+        reasoningTokens: 10,
+      },
+      {
+        source: "codex",
+        model: "gpt-5.4",
+        project: "tokenarena",
+        timestamp: new Date("2026-03-26T10:00:10.000Z"),
+        inputTokens: -90,
+        outputTokens: 40,
+        cachedTokens: 120,
+        reasoningTokens: 0,
+      },
+    ]);
+
+    expect(bucket.inputTokens).toBe(100);
+    expect(bucket.outputTokens).toBe(60);
+    expect(bucket.cachedTokens).toBe(25);
+    expect(bucket.reasoningTokens).toBe(10);
+    expect(bucket.totalTokens).toBe(195);
+  });
 });

--- a/cli/src/domain/aggregator.ts
+++ b/cli/src/domain/aggregator.ts
@@ -1,4 +1,5 @@
 import { hostname } from "node:os";
+import { hasInvalidTokenCounts } from "./token-usage";
 import type { TokenBucket, TokenUsageEntry } from "./types";
 
 /**
@@ -18,6 +19,10 @@ export function aggregateToBuckets(entries: TokenUsageEntry[]): TokenBucket[] {
   const host = hostname().replace(/\.local$/, "");
 
   for (const e of entries) {
+    if (hasInvalidTokenCounts(e)) {
+      continue;
+    }
+
     const bucketStart = roundToHalfHour(e.timestamp).toISOString();
     const key = `${e.source}|${e.model}|${e.project}|${bucketStart}`;
 

--- a/cli/src/domain/session-extractor.test.ts
+++ b/cli/src/domain/session-extractor.test.ts
@@ -74,4 +74,66 @@ describe("extractSessions", () => {
       },
     ]);
   });
+
+  it("ignores malformed token usage entries with negative counts", () => {
+    const [session] = extractSessions(
+      [
+        {
+          sessionId: "s1",
+          source: "claude-code",
+          project: "tokenarena",
+          timestamp: new Date("2026-03-26T10:00:00.000Z"),
+          role: "user",
+        },
+        {
+          sessionId: "s1",
+          source: "claude-code",
+          project: "tokenarena",
+          timestamp: new Date("2026-03-26T10:00:05.000Z"),
+          role: "assistant",
+        },
+      ],
+      [
+        {
+          sessionId: "s1",
+          source: "claude-code",
+          model: "claude-sonnet-4-20250514",
+          project: "tokenarena",
+          timestamp: new Date("2026-03-26T10:00:05.000Z"),
+          inputTokens: 100,
+          outputTokens: 60,
+          cachedTokens: 25,
+          reasoningTokens: 10,
+        },
+        {
+          sessionId: "s1",
+          source: "claude-code",
+          model: "claude-opus-4-20250514",
+          project: "tokenarena",
+          timestamp: new Date("2026-03-26T10:00:06.000Z"),
+          inputTokens: -40,
+          outputTokens: 20,
+          cachedTokens: 120,
+          reasoningTokens: 0,
+        },
+      ],
+    );
+
+    expect(session.inputTokens).toBe(100);
+    expect(session.outputTokens).toBe(60);
+    expect(session.reasoningTokens).toBe(10);
+    expect(session.cachedTokens).toBe(25);
+    expect(session.totalTokens).toBe(195);
+    expect(session.primaryModel).toBe("claude-sonnet-4-20250514");
+    expect(session.modelUsages).toEqual([
+      {
+        model: "claude-sonnet-4-20250514",
+        inputTokens: 100,
+        outputTokens: 60,
+        reasoningTokens: 10,
+        cachedTokens: 25,
+        totalTokens: 195,
+      },
+    ]);
+  });
 });

--- a/cli/src/domain/session-extractor.ts
+++ b/cli/src/domain/session-extractor.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { hostname } from "node:os";
+import { hasInvalidTokenCounts } from "./token-usage";
 import type {
   SessionEvent,
   SessionMetadata,
@@ -21,6 +22,10 @@ function buildSessionUsage(entries: TokenUsageEntry[]) {
 
   for (const entry of entries) {
     if (!entry.sessionId) {
+      continue;
+    }
+
+    if (hasInvalidTokenCounts(entry)) {
       continue;
     }
 

--- a/cli/src/domain/token-usage.ts
+++ b/cli/src/domain/token-usage.ts
@@ -1,0 +1,17 @@
+import type { TokenUsageEntry } from "./types";
+
+const TOKEN_COUNT_KEYS = [
+  "inputTokens",
+  "outputTokens",
+  "reasoningTokens",
+  "cachedTokens",
+] as const;
+
+export function hasInvalidTokenCounts(
+  entry: Pick<TokenUsageEntry, (typeof TOKEN_COUNT_KEYS)[number]>,
+): boolean {
+  return TOKEN_COUNT_KEYS.some((key) => {
+    const value = entry[key];
+    return !Number.isSafeInteger(value) || value < 0;
+  });
+}

--- a/cli/src/parsers/opencode.test.ts
+++ b/cli/src/parsers/opencode.test.ts
@@ -1,0 +1,77 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { OpenCodeParser } from "./opencode";
+
+describe("OpenCodeParser", () => {
+  const originalOpenCodeDir = process.env.TOKEN_ARENA_OPENCODE_DIR;
+  const createdDirs: string[] = [];
+
+  afterEach(() => {
+    process.env.TOKEN_ARENA_OPENCODE_DIR = originalOpenCodeDir;
+
+    for (const dir of createdDirs.splice(0)) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it("ignores malformed negative token usage entries from json storage", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "tokenarena-opencode-"));
+    createdDirs.push(rootDir);
+
+    const sessionDir = join(rootDir, "storage", "message", "ses_1");
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(
+      join(sessionDir, "msg-1.json"),
+      JSON.stringify({
+        created: "2026-01-12T14:49:26.154Z",
+        modelID: "gemini-claude-opus-4-5-thinking",
+        path: {
+          root: "E:\\Users\\User\\Desktop\\ParticleSaturn",
+        },
+        role: "assistant",
+        time: {
+          created: "2026-01-12T14:49:26.154Z",
+        },
+        tokens: {
+          input: -9053,
+          output: 70,
+          reasoning: 0,
+          cache: {
+            read: 12068,
+          },
+        },
+      }),
+      "utf-8",
+    );
+    writeFileSync(
+      join(sessionDir, "msg-0.json"),
+      JSON.stringify({
+        created: "2026-01-12T14:49:26.140Z",
+        role: "user",
+        time: {
+          created: "2026-01-12T14:49:26.140Z",
+        },
+      }),
+      "utf-8",
+    );
+
+    const parser = new OpenCodeParser(() => [rootDir]);
+    const result = await parser.parse();
+
+    expect(result.buckets).toEqual([]);
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]).toMatchObject({
+      source: "opencode",
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      cachedTokens: 0,
+      totalTokens: 0,
+      primaryModel: "",
+      modelUsages: [],
+    });
+  });
+});

--- a/cli/src/parsers/opencode.ts
+++ b/cli/src/parsers/opencode.ts
@@ -180,14 +180,18 @@ function readSqliteRowsWithCli(dbPath: string, query: string): SqliteRow[] {
   );
 }
 
-class OpenCodeParser implements IParser {
+export class OpenCodeParser implements IParser {
   readonly tool = TOOL;
+
+  constructor(
+    private readonly resolveRoots: () => string[] = getOpenCodeDataDirs,
+  ) {}
 
   async parse(): Promise<ParseResult> {
     const buckets: ParseResult["buckets"] = [];
     const sessions: ParseResult["sessions"] = [];
 
-    for (const rootDir of getOpenCodeDataDirs()) {
+    for (const rootDir of this.resolveRoots()) {
       const result = await this.parseRoot(rootDir);
       if (result.buckets.length > 0) {
         buckets.push(...result.buckets);
@@ -201,7 +205,7 @@ class OpenCodeParser implements IParser {
   }
 
   isInstalled(): boolean {
-    return getOpenCodeDataDirs().some((dir) => existsSync(dir));
+    return this.resolveRoots().some((dir) => existsSync(dir));
   }
 
   private async parseRoot(rootDir: string): Promise<ParseResult> {


### PR DESCRIPTION
针对https://github.com/poco-ai/TokenArena/issues/19 的修复，由Codex完成。  

## 背景

  在执行 `tokenarena init` / `tokenarena sync` 时，首次同步可能失败，报错类似：

  HTTP 400: {"error":"INVALID_PAYLOAD","issues":{"formErrors":[],"fieldErrors":{"sessions":["Too small: expected number to be >=0","Too small: expected number to be >=0"]}}}

  排查后发现，问题是本地解析出的 sessions 数据中混入了负数 token 值。

  本地复现时，异常样本来自 OpenCode 数据，存在类似记录（我也不知道为什么会有这种逆天边缘情况，或许是当时用的反重力反代没能正确统计token？）：

  - tokens.input = -9053
  - tokens.cache.read = 12068

  CLI 会把这类异常值直接带入 session 聚合结果，最终上传到服务端后触发 Zod 的 nonnegative() 校验失败，导致接口返回 INVALID_PAYLOAD。

  ## 变更内容

  - 新增通用 token 计数校验逻辑，过滤负数或非安全整数的 token 记录
  - 在 bucket 聚合阶段跳过异常 token 记录，避免脏数据进入上传 payload
  - 在 session 聚合阶段同样跳过异常 token 记录，避免 sessions / modelUsages 中出现负数
  - 为 OpenCode parser 增加回归测试，覆盖负数 token 场景
  - 为聚合器和 session 提取逻辑补充测试，覆盖“正常记录 + 异常记录混合”场景

  ## 修复效果

  修复后，即使 OpenCode 本地数据中存在异常负 token 记录：

  - 同步流程不会再因为 sessions 字段校验失败而返回 HTTP 400
  - 合法记录仍会正常聚合和上传
  - 异常记录会被静默跳过，不污染 bucket / session 统计结果