### PR TITLE
feat(cli): 新增 GSD-2 与 Oh My Pi JSONL 对话解析器

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,9 +1,11 @@
 // Import parsers to register them before CLI setup
 import "./parsers/claude-code.js";
 import "./parsers/codex.js";
+import "./parsers/gsd.js";
 import "./parsers/gemini-cli.js";
 import "./parsers/hermes.js";
 import "./parsers/copilot-cli.js";
+import "./parsers/oh-my-pi.js";
 import "./parsers/opencode.js";
 import "./parsers/openclaw.js";
 import "./parsers/qwen-code.js";

--- a/cli/src/parsers/gsd.test.ts
+++ b/cli/src/parsers/gsd.test.ts
@@ -1,0 +1,115 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  extractGsdProjectFromCwd,
+  extractGsdProjectFromDir,
+  GsdParser,
+} from "./gsd";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("gsd project resolution", () => {
+  it("extracts the cwd leaf when a session header is present", () => {
+    expect(extractGsdProjectFromCwd("/Users/dev/tokenarena")).toBe(
+      "tokenarena",
+    );
+  });
+
+  it("decodes URI-encoded workspace directories", () => {
+    expect(
+      extractGsdProjectFromDir(
+        "/tmp/sessions/%2FUsers%2Fdev%2Ftokenarena/session-1.jsonl",
+        "/tmp/sessions",
+      ),
+    ).toBe("tokenarena");
+  });
+});
+
+describe("GsdParser", () => {
+  it("parses GSD-2 sessions and ignores toolResult messages", async () => {
+    const sessionsDir = makeTempDir("tokenarena-gsd-");
+    const sessionFileDir = join(sessionsDir, "workspace-tokenarena");
+    mkdirSync(sessionFileDir, { recursive: true });
+
+    const sessionPath = join(sessionFileDir, "20260326_sess-1.jsonl");
+    writeFileSync(
+      sessionPath,
+      [
+        JSON.stringify({
+          type: "session",
+          id: "sess-1",
+          cwd: "/Users/dev/tokenarena",
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-03-26T10:00:00.000Z",
+          message: { role: "user" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "msg-1",
+          timestamp: "2026-03-26T10:00:04.000Z",
+          message: {
+            role: "assistant",
+            model: "gpt-5.4",
+            usage: {
+              input: 100,
+              output: 30,
+              cacheRead: 20,
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-03-26T10:00:05.000Z",
+          message: { role: "toolResult" },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const parser = new GsdParser(sessionsDir);
+    const result = await parser.parse();
+
+    expect(result.buckets).toHaveLength(1);
+    expect(result.buckets[0]).toMatchObject({
+      source: "gsd",
+      model: "gpt-5.4",
+      project: "tokenarena",
+      inputTokens: 100,
+      outputTokens: 30,
+      reasoningTokens: 0,
+      cachedTokens: 20,
+      totalTokens: 150,
+    });
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]).toMatchObject({
+      source: "gsd",
+      project: "tokenarena",
+      durationSeconds: 4,
+      messageCount: 2,
+      userMessageCount: 1,
+      inputTokens: 100,
+      outputTokens: 30,
+      reasoningTokens: 0,
+      cachedTokens: 20,
+      totalTokens: 150,
+      primaryModel: "gpt-5.4",
+    });
+  });
+});

--- a/cli/src/parsers/gsd.ts
+++ b/cli/src/parsers/gsd.ts
@@ -1,0 +1,241 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { aggregateToBuckets } from "../domain/aggregator";
+import { extractSessions } from "../domain/session-extractor";
+import type {
+  ParseResult,
+  SessionEvent,
+  TokenUsageEntry,
+} from "../domain/types";
+import {
+  findJsonlFiles,
+  parseJsonl,
+  readFileSafe,
+} from "../infrastructure/fs/utils";
+import { registerParser } from "./registry";
+import type { IParser, ToolDefinition } from "./types";
+
+const TOOL_ID = "gsd";
+const TOOL_NAME = "GSD-2";
+const DEFAULT_SESSIONS_DIR = join(homedir(), ".gsd", "sessions");
+
+interface GsdUsage {
+  input?: number;
+  inputTokens?: number;
+  output?: number;
+  outputTokens?: number;
+  cacheRead?: number;
+  cacheReadTokens?: number;
+  cache_read?: number;
+  reasoningOutputTokens?: number;
+  thinkingTokens?: number;
+  thoughts?: number;
+}
+
+interface GsdEvent {
+  type?: string;
+  id?: string;
+  timestamp?: string;
+  cwd?: string;
+  message?: {
+    role?: string;
+    timestamp?: string;
+    model?: string;
+    usage?: GsdUsage;
+  };
+}
+
+function createToolDefinition(dataDir: string): ToolDefinition {
+  return {
+    id: TOOL_ID,
+    name: TOOL_NAME,
+    dataDir,
+  };
+}
+
+function toSafeNumber(value: unknown): number {
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : 0;
+}
+
+function getPathLeaf(value: string): string {
+  const normalized = value.replace(/\\/g, "/").replace(/\/+$/, "");
+  const leaf = normalized.split("/").filter(Boolean).pop();
+  return leaf || "unknown";
+}
+
+function normalizeForPrefix(value: string): string {
+  return value.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function getUsageNumber(
+  usage: GsdUsage,
+  ...keys: Array<keyof GsdUsage>
+): number {
+  for (const key of keys) {
+    const value = usage[key];
+    const numberValue = toSafeNumber(value);
+    if (numberValue > 0) {
+      return numberValue;
+    }
+  }
+
+  return 0;
+}
+
+export function extractGsdProjectFromCwd(cwd: string): string {
+  return getPathLeaf(cwd);
+}
+
+export function extractGsdProjectFromDir(
+  filePath: string,
+  sessionsDir = DEFAULT_SESSIONS_DIR,
+): string {
+  const normalizedFilePath = normalizeForPrefix(filePath);
+  const normalizedSessionsDir = normalizeForPrefix(sessionsDir);
+  const prefix = `${normalizedSessionsDir}/`;
+
+  if (!normalizedFilePath.startsWith(prefix)) {
+    return "unknown";
+  }
+
+  const relativePath = normalizedFilePath.slice(prefix.length);
+  const firstSegment = relativePath.split("/")[0];
+  if (!firstSegment) {
+    return "unknown";
+  }
+
+  try {
+    const decoded = decodeURIComponent(firstSegment);
+    if (decoded.includes("/") || decoded.includes("\\")) {
+      return getPathLeaf(decoded);
+    }
+  } catch {
+    // Fall back to slug parsing when the segment is not URI-encoded.
+  }
+
+  const slugParts = firstSegment.split("-").filter(Boolean);
+  return slugParts.length > 0 ? slugParts[slugParts.length - 1] : "unknown";
+}
+
+export class GsdParser implements IParser {
+  readonly tool: ToolDefinition;
+
+  constructor(private readonly sessionsDir = DEFAULT_SESSIONS_DIR) {
+    this.tool = createToolDefinition(sessionsDir);
+  }
+
+  async parse(): Promise<ParseResult> {
+    const sessionFiles = findJsonlFiles(this.sessionsDir);
+    if (sessionFiles.length === 0) {
+      return { buckets: [], sessions: [] };
+    }
+
+    const entries: TokenUsageEntry[] = [];
+    const sessionEvents: SessionEvent[] = [];
+    const seenEntryIds = new Set<string>();
+
+    for (const filePath of sessionFiles) {
+      const content = readFileSafe(filePath);
+      if (!content) continue;
+
+      const rows = parseJsonl<GsdEvent>(content);
+      if (rows.length === 0) continue;
+
+      let sessionId = filePath;
+      let project = extractGsdProjectFromDir(filePath, this.sessionsDir);
+
+      for (const row of rows) {
+        if (row.type !== "session") continue;
+        if (row.id) {
+          sessionId = row.id;
+        }
+        if (row.cwd) {
+          project = extractGsdProjectFromCwd(row.cwd);
+        }
+        break;
+      }
+
+      for (const row of rows) {
+        if (row.type !== "message") continue;
+
+        const message = row.message;
+        if (!message) continue;
+
+        const rawTimestamp = row.timestamp || message.timestamp;
+        if (!rawTimestamp) continue;
+
+        const timestamp = new Date(rawTimestamp);
+        if (Number.isNaN(timestamp.getTime())) continue;
+
+        if (message.role === "user" || message.role === "assistant") {
+          sessionEvents.push({
+            sessionId,
+            source: TOOL_ID,
+            project,
+            timestamp,
+            role: message.role,
+          });
+        }
+
+        if (message.role !== "assistant") continue;
+
+        const usage = message.usage;
+        if (!usage) continue;
+
+        const inputTokens = getUsageNumber(usage, "input", "inputTokens");
+        const outputTokens = getUsageNumber(usage, "output", "outputTokens");
+        const cachedTokens = getUsageNumber(
+          usage,
+          "cacheRead",
+          "cacheReadTokens",
+          "cache_read",
+        );
+        const reasoningTokens = getUsageNumber(
+          usage,
+          "reasoningOutputTokens",
+          "thinkingTokens",
+          "thoughts",
+        );
+
+        if (
+          inputTokens === 0 &&
+          outputTokens === 0 &&
+          cachedTokens === 0 &&
+          reasoningTokens === 0
+        ) {
+          continue;
+        }
+
+        if (row.id) {
+          if (seenEntryIds.has(row.id)) continue;
+          seenEntryIds.add(row.id);
+        }
+
+        entries.push({
+          sessionId,
+          source: TOOL_ID,
+          model: message.model || "unknown",
+          project,
+          timestamp,
+          inputTokens,
+          outputTokens,
+          reasoningTokens,
+          cachedTokens,
+        });
+      }
+    }
+
+    return {
+      buckets: aggregateToBuckets(entries),
+      sessions: extractSessions(sessionEvents, entries),
+    };
+  }
+
+  isInstalled(): boolean {
+    return existsSync(this.sessionsDir);
+  }
+}
+
+registerParser(new GsdParser());

--- a/cli/src/parsers/oh-my-pi.test.ts
+++ b/cli/src/parsers/oh-my-pi.test.ts
@@ -1,0 +1,115 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  extractOhMyPiProjectFromCwd,
+  extractOhMyPiProjectFromDir,
+  OhMyPiParser,
+} from "./oh-my-pi";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("oh-my-pi project resolution", () => {
+  it("extracts the cwd leaf when a session header is present", () => {
+    expect(extractOhMyPiProjectFromCwd("/Users/dev/tokenarena")).toBe(
+      "tokenarena",
+    );
+  });
+
+  it("decodes URI-encoded workspace directories", () => {
+    expect(
+      extractOhMyPiProjectFromDir(
+        "/tmp/sessions/%2FUsers%2Fdev%2Ftokenarena/session-1.jsonl",
+        "/tmp/sessions",
+      ),
+    ).toBe("tokenarena");
+  });
+});
+
+describe("OhMyPiParser", () => {
+  it("parses oh-my-pi sessions and ignores toolResult messages", async () => {
+    const sessionsDir = makeTempDir("tokenarena-oh-my-pi-");
+    const sessionFileDir = join(sessionsDir, "workspace-tokenarena");
+    mkdirSync(sessionFileDir, { recursive: true });
+
+    const sessionPath = join(sessionFileDir, "20260326_sess-1.jsonl");
+    writeFileSync(
+      sessionPath,
+      [
+        JSON.stringify({
+          type: "session",
+          id: "sess-1",
+          cwd: "/Users/dev/tokenarena",
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-03-26T10:00:00.000Z",
+          message: { role: "user" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "msg-1",
+          timestamp: "2026-03-26T10:00:04.000Z",
+          message: {
+            role: "assistant",
+            model: "gpt-5.4",
+            usage: {
+              input: 100,
+              output: 30,
+              cacheRead: 20,
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-03-26T10:00:05.000Z",
+          message: { role: "toolResult" },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const parser = new OhMyPiParser(sessionsDir);
+    const result = await parser.parse();
+
+    expect(result.buckets).toHaveLength(1);
+    expect(result.buckets[0]).toMatchObject({
+      source: "oh-my-pi",
+      model: "gpt-5.4",
+      project: "tokenarena",
+      inputTokens: 100,
+      outputTokens: 30,
+      reasoningTokens: 0,
+      cachedTokens: 20,
+      totalTokens: 150,
+    });
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]).toMatchObject({
+      source: "oh-my-pi",
+      project: "tokenarena",
+      durationSeconds: 4,
+      messageCount: 2,
+      userMessageCount: 1,
+      inputTokens: 100,
+      outputTokens: 30,
+      reasoningTokens: 0,
+      cachedTokens: 20,
+      totalTokens: 150,
+      primaryModel: "gpt-5.4",
+    });
+  });
+});

--- a/cli/src/parsers/oh-my-pi.ts
+++ b/cli/src/parsers/oh-my-pi.ts
@@ -1,0 +1,241 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { aggregateToBuckets } from "../domain/aggregator";
+import { extractSessions } from "../domain/session-extractor";
+import type {
+  ParseResult,
+  SessionEvent,
+  TokenUsageEntry,
+} from "../domain/types";
+import {
+  findJsonlFiles,
+  parseJsonl,
+  readFileSafe,
+} from "../infrastructure/fs/utils";
+import { registerParser } from "./registry";
+import type { IParser, ToolDefinition } from "./types";
+
+const TOOL_ID = "oh-my-pi";
+const TOOL_NAME = "omp";
+const DEFAULT_SESSIONS_DIR = join(homedir(), ".omp", "agent", "sessions");
+
+interface OhMyPiUsage {
+  input?: number;
+  inputTokens?: number;
+  output?: number;
+  outputTokens?: number;
+  cacheRead?: number;
+  cacheReadTokens?: number;
+  cache_read?: number;
+  reasoningOutputTokens?: number;
+  thinkingTokens?: number;
+  thoughts?: number;
+}
+
+interface OhMyPiEvent {
+  type?: string;
+  id?: string;
+  timestamp?: string;
+  cwd?: string;
+  message?: {
+    role?: string;
+    timestamp?: string;
+    model?: string;
+    usage?: OhMyPiUsage;
+  };
+}
+
+function createToolDefinition(dataDir: string): ToolDefinition {
+  return {
+    id: TOOL_ID,
+    name: TOOL_NAME,
+    dataDir,
+  };
+}
+
+function toSafeNumber(value: unknown): number {
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : 0;
+}
+
+function getPathLeaf(value: string): string {
+  const normalized = value.replace(/\\/g, "/").replace(/\/+$/, "");
+  const leaf = normalized.split("/").filter(Boolean).pop();
+  return leaf || "unknown";
+}
+
+function normalizeForPrefix(value: string): string {
+  return value.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function getUsageNumber(
+  usage: OhMyPiUsage,
+  ...keys: Array<keyof OhMyPiUsage>
+): number {
+  for (const key of keys) {
+    const value = usage[key];
+    const numberValue = toSafeNumber(value);
+    if (numberValue > 0) {
+      return numberValue;
+    }
+  }
+
+  return 0;
+}
+
+export function extractOhMyPiProjectFromCwd(cwd: string): string {
+  return getPathLeaf(cwd);
+}
+
+export function extractOhMyPiProjectFromDir(
+  filePath: string,
+  sessionsDir = DEFAULT_SESSIONS_DIR,
+): string {
+  const normalizedFilePath = normalizeForPrefix(filePath);
+  const normalizedSessionsDir = normalizeForPrefix(sessionsDir);
+  const prefix = `${normalizedSessionsDir}/`;
+
+  if (!normalizedFilePath.startsWith(prefix)) {
+    return "unknown";
+  }
+
+  const relativePath = normalizedFilePath.slice(prefix.length);
+  const firstSegment = relativePath.split("/")[0];
+  if (!firstSegment) {
+    return "unknown";
+  }
+
+  try {
+    const decoded = decodeURIComponent(firstSegment);
+    if (decoded.includes("/") || decoded.includes("\\")) {
+      return getPathLeaf(decoded);
+    }
+  } catch {
+    // Fall back to slug parsing when the segment is not URI-encoded.
+  }
+
+  const slugParts = firstSegment.split("-").filter(Boolean);
+  return slugParts.length > 0 ? slugParts[slugParts.length - 1] : "unknown";
+}
+
+export class OhMyPiParser implements IParser {
+  readonly tool: ToolDefinition;
+
+  constructor(private readonly sessionsDir = DEFAULT_SESSIONS_DIR) {
+    this.tool = createToolDefinition(sessionsDir);
+  }
+
+  async parse(): Promise<ParseResult> {
+    const sessionFiles = findJsonlFiles(this.sessionsDir);
+    if (sessionFiles.length === 0) {
+      return { buckets: [], sessions: [] };
+    }
+
+    const entries: TokenUsageEntry[] = [];
+    const sessionEvents: SessionEvent[] = [];
+    const seenEntryIds = new Set<string>();
+
+    for (const filePath of sessionFiles) {
+      const content = readFileSafe(filePath);
+      if (!content) continue;
+
+      const rows = parseJsonl<OhMyPiEvent>(content);
+      if (rows.length === 0) continue;
+
+      let sessionId = filePath;
+      let project = extractOhMyPiProjectFromDir(filePath, this.sessionsDir);
+
+      for (const row of rows) {
+        if (row.type !== "session") continue;
+        if (row.id) {
+          sessionId = row.id;
+        }
+        if (row.cwd) {
+          project = extractOhMyPiProjectFromCwd(row.cwd);
+        }
+        break;
+      }
+
+      for (const row of rows) {
+        if (row.type !== "message") continue;
+
+        const message = row.message;
+        if (!message) continue;
+
+        const rawTimestamp = row.timestamp || message.timestamp;
+        if (!rawTimestamp) continue;
+
+        const timestamp = new Date(rawTimestamp);
+        if (Number.isNaN(timestamp.getTime())) continue;
+
+        if (message.role === "user" || message.role === "assistant") {
+          sessionEvents.push({
+            sessionId,
+            source: TOOL_ID,
+            project,
+            timestamp,
+            role: message.role,
+          });
+        }
+
+        if (message.role !== "assistant") continue;
+
+        const usage = message.usage;
+        if (!usage) continue;
+
+        const inputTokens = getUsageNumber(usage, "input", "inputTokens");
+        const outputTokens = getUsageNumber(usage, "output", "outputTokens");
+        const cachedTokens = getUsageNumber(
+          usage,
+          "cacheRead",
+          "cacheReadTokens",
+          "cache_read",
+        );
+        const reasoningTokens = getUsageNumber(
+          usage,
+          "reasoningOutputTokens",
+          "thinkingTokens",
+          "thoughts",
+        );
+
+        if (
+          inputTokens === 0 &&
+          outputTokens === 0 &&
+          cachedTokens === 0 &&
+          reasoningTokens === 0
+        ) {
+          continue;
+        }
+
+        if (row.id) {
+          if (seenEntryIds.has(row.id)) continue;
+          seenEntryIds.add(row.id);
+        }
+
+        entries.push({
+          sessionId,
+          source: TOOL_ID,
+          model: message.model || "unknown",
+          project,
+          timestamp,
+          inputTokens,
+          outputTokens,
+          reasoningTokens,
+          cachedTokens,
+        });
+      }
+    }
+
+    return {
+      buckets: aggregateToBuckets(entries),
+      sessions: extractSessions(sessionEvents, entries),
+    };
+  }
+
+  isInstalled(): boolean {
+    return existsSync(this.sessionsDir);
+  }
+}
+
+registerParser(new OhMyPiParser());


### PR DESCRIPTION
## 变更内容

为 CLI 新增两个 JSONL 会话解析器，将 GSD-2 和 Oh My Pi 平台的对话日志接入统一的 Token 用量聚合管道。

### 新增文件

- **`cli/src/parsers/gsd.ts`** — GSD-2 JSONL 格式解析器
- **`cli/src/parsers/oh-my-pi.ts`** — Oh My Pi JSONL 格式解析器
- **`cli/src/parsers/gsd.test.ts`** / **`cli/src/parsers/oh-my-pi.test.ts`** — 配套测试

### 工作内容

- 实现了 JSONL 事件解析、项目提取、用量归一化及去重逻辑
- 通过共享聚合管道将解析后的 Token 用量注入后续处理流程
- 在 `cli/src/index.ts` 中以 side-effect import 注册两个解析器
- 测试覆盖事件解析、项目提取、用量归一化与去重场景

## 验证方式

```bash
pnpm check
pnpm build
pnpm --filter ./cli dev -- --help
```