### PR TITLE
fix(cli): reload config on each daemon sync cycle

### DIFF
--- a/cli/src/commands/daemon.ts
+++ b/cli/src/commands/daemon.ts
@@ -66,7 +66,8 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<void> {
   // eslint-disable-next-line no-constant-condition
   while (true) {
     try {
-      await runSync(config, {
+      const fresh = loadConfig();
+      await runSync(fresh ?? config, {
         quiet: true,
         source: "daemon",
         throws: true,


### PR DESCRIPTION
## Summary

- Reload config from disk before every daemon sync iteration so changes made via `tokenarena config set` (apiKey, apiUrl, etc.) take effect without a manual `service restart`

## Context

The daemon only called `loadConfig()` once at startup, then reused that config object in its sync loop. After modifying config values, the daemon continued using stale credentials, causing "Could not fetch usage settings" errors until `tokenarena service restart` was run.

## Test plan

- [ ] Start daemon with valid config
- [ ] Run `tokenarena config set apiKey <new-key>`
- [ ] Verify daemon picks up the new key on the next sync cycle (no restart needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)